### PR TITLE
Auto-add uploaded zoom video to YouTube playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install -r requirements.txt
 # Copy client_secret.json to repo root dir. This is downloaded from
 # Google API Console, and will need to be renamed.
 
-# Authorize YouTube app with [EDGI] account
+# Authorize YouTube app with EDGI account
 # This will need to be done from a system with a windowed browser (ie.
 # not a server). If running the script on a server is required, you will
 # need to transfer the `.youtube-upload-credentials.json` file from your

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ tool](https://github.com/edgi-govdata-archiving/overview/issues/149).
 
 ## Zoom-YouTube Uploader
 
+This script cycles through Zoom cloud recordings and for each:
+
+* uploads video to youtube as unlisted video
+* adds it to a default playlist (which happens to be unlisted)
+* sets video title to be `<title> - Mmm DD, YYYY` of recorded date
+* does **not** delete original from Zoom
+* stupidly allows duplicates, but YouTube will recognize and disable
+  them after upload
+
 **Setup**
 
 Quick reference for Ubuntu (may vary).

--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ mkvirtualenv edgi-scripts --python=`which python3`
 workon edgi-scripts
 pip install -r requirements.txt
 
-# Copy client_secret.json to repo root dir
+# Copy client_secret.json to repo root dir. This is downloaded from
+# Google API Console, and will need to be renamed.
 
 # Authorize YouTube app with [EDGI] account
+# This will need to be done from a system with a windowed browser (ie.
+# not a server). If running the script on a server is required, you will
+# need to transfer the `.youtube-upload-credentials.json` file from your
+# workstation onto the server.
 python scripts/auth.py
 
 # Prepare to download all videos from Zoom

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -13,6 +13,7 @@ ZOOM_API_KEY = os.environ['EDGI_ZOOM_API_KEY']
 ZOOM_API_SECRET = os.environ['EDGI_ZOOM_API_SECRET']
 
 MEETINGS_TO_RECORD = ['EDGI Community Standup']
+DEFAULT_YOUTUBE_PLAYLIST = 'Uploads from Zoom'
 
 client = ZoomClient(ZOOM_API_KEY, ZOOM_API_SECRET)
 
@@ -68,6 +69,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                     command = [
                             "youtube-upload", filepath,
                             "--title=" + title,
+                            "--playlist=" + DEFAULT_YOUTUBE_PLAYLIST,
                             "--recording-date=" + fix_date(meeting['start_time']),
                             "--privacy=unlisted",
                             "--client-secrets=client_secret.json",


### PR DESCRIPTION
## Problem

* Most every EDGI video is unlisted to preserve privacy
* unlisted videos can only be browsed by YouTube admins
* otherwise, they require someone to share the video link
* ideally, this would be in the meeting index, but sometimes this doesn't fit
* we currently have an upload script (in this repo) that I run remotely from a server with a highspeed connection. this script is intended to be run by a visual script-runner soon: https://github.com/edgi-govdata-archiving/overview/issues/149

## Solution
* create an unlisted YouTube playlist that we share widely within EDGI Slack
* modify upload script so that it auto-adds each uploaded video to the playlist
* now, people know every video uploaded from zoom will be there

## Notes

* this will make hubot's upload command simpler, since it can stay "stateless" -- it won't need to drop a message in chat or keep polling for upload status -- it can just say "hey, it'll be in this playlist when it's done in 3 minutes"
* The playlist ID will be in an envvar so it won't be revealed in this repo.

## Related
- https://github.com/edgi-govdata-archiving/edgi-hubot/issues/26