### PR TITLE
Delete videos from Zoom after uploading to YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This script cycles through Zoom cloud recordings and for each:
 * uploads video to youtube as unlisted video
 * adds it to a default playlist (which happens to be unlisted)
 * sets video title to be `<title> - Mmm DD, YYYY` of recorded date
-* does **not** delete original from Zoom
+* **deletes** original video file from Zoom (**not** audio or chat log)
 * stupidly allows duplicates, but YouTube will recognize and disable
   them after upload
 

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -62,7 +62,8 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         print('Recording is permitted for upload!')
         for file in meeting['recording_files']:
             if file['file_size'] == 0:
-                print('File still processing...')
+                print('Meeting still processing: {}'.format(meeting['topic']))
+                break
             else:
                 if file['file_type'].lower() == 'mp4':
                     url = file['download_url']

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -12,6 +12,9 @@ from zoomus import ZoomClient
 ZOOM_API_KEY = os.environ['EDGI_ZOOM_API_KEY']
 ZOOM_API_SECRET = os.environ['EDGI_ZOOM_API_SECRET']
 
+def is_truthy(x): return x.lower() in ['true', '1', 'y', 'yes']
+ZOOM_DELETE_AFTER_UPLOAD = is_truthy(os.environ.get('EDGI_ZOOM_DELETE_AFTER_UPLOAD', ''))
+
 MEETINGS_TO_RECORD = ['EDGI Community Standup']
 DEFAULT_YOUTUBE_PLAYLIST = 'Uploads from Zoom'
 
@@ -76,4 +79,9 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                             "--credentials-file=.youtube-upload-credentials.json"
                             ]
                     out = check_output(command)
+                    if ZOOM_DELETE_AFTER_UPLOAD:
+                        # Just delete the video for now, since that takes the most storage space.
+                        # We should save the chat log transcript in a comment on the video.
+                        client.recording.delete(meeting_id=file['meeting_id'])
+                        print("Deleted cloud recording from Zoom.")
                     print(out)

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -83,6 +83,6 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                     if ZOOM_DELETE_AFTER_UPLOAD:
                         # Just delete the video for now, since that takes the most storage space.
                         # We should save the chat log transcript in a comment on the video.
-                        client.recording.delete(meeting_id=file['meeting_id'])
-                        print("Deleted cloud recording from Zoom.")
+                        client.recording.delete(meeting_id=file['meeting_id'], file_id=file['id'])
+                        print("Deleted {} file from Zoom for recording: {}".format(meeting['topic'], file['file_type']))
                     print(out)


### PR DESCRIPTION
This will allow Zoom space to be freed up once the script has run, which will avoid future complications.