### PR TITLE
Fix youtube upload script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ client_secret.json
 .youtube-upload-credentials.json
 *.json
 *.mp4
+__pycache__/

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,5 @@
+USER_TYPES = {
+        'basic': 1,
+        'pro': 2,
+        'corp': 3,
+        }

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -8,6 +8,7 @@ from subprocess import check_output
 import tempfile
 from urllib.parse import urlparse
 from zoomus import ZoomClient
+from constants import USER_TYPES
 
 ZOOM_API_KEY = os.environ['EDGI_ZOOM_API_KEY']
 ZOOM_API_SECRET = os.environ['EDGI_ZOOM_API_SECRET']
@@ -20,8 +21,9 @@ DEFAULT_YOUTUBE_PLAYLIST = 'Uploads from Zoom'
 
 client = ZoomClient(ZOOM_API_KEY, ZOOM_API_SECRET)
 
-# Assumes first id is main account
-user_id = json.loads(client.user.list().text)['users'][0]['id']
+# Get main account, which should be 'pro'
+pro_users = [user for user in client.user.list().json()['users'] if user['type'] >= USER_TYPES['pro'] ]
+user_id = pro_users[0]['id']
 
 def fix_date(date_string):
     date = date_string


### PR DESCRIPTION
The script made the assumption that the first account returned was the pro account. When ray was added a sub-user to the EDGI Zoom account, he become the first user returns, and that account didn't have the required permissions of the pro account.

We're now filtering the list to pro account types, which seems to resolves.

I'm waiting on merge, because there is such a backlog of videos, and I want to do some locally before I let travis handle them all. (I'm slightly worried that space on the Digital Ocean droplet might fill up, and then download and delete a bunch, then fail to upload... Ideally, the script would be more intelligent so that this couldn't happen, but I want to be safe.)