### PR TITLE
Make video uploads use the creativeCommons license

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ bash scripts/archive.sh envirodatagov.org
 This script cycles through Zoom cloud recordings and for each:
 
 * uploads video to youtube as unlisted video
-* adds it to a default playlist (which happens to be unlisted)
 * sets video title to be `<Zoom title> - Mmm DD, YYYY` of recorded date
-* Adds video to call-specific playlist based on meeting title:
+* sets video license to "Creative Commons - Attribution"
+* sets video category to "Science & Technology"
+* adds video to a default unlisted playlist, "Uploads from Zoom"
+* adds video to call-specific playlist based on meeting title:
   * "Website Monitoring" (alternatively, "Web Mon" or "WM")
   * "Data Together"
   * "Community Call"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
--e git://github.com/tokland/youtube-upload.git@master#egg=youtube-upload
+-e git://github.com/edgi-govdata-archiving/youtube-upload.git@add-license-option#egg=youtube-upload
 zoomus

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -48,6 +48,7 @@ ZOOM_DELETE_AFTER_UPLOAD = is_truthy(os.environ.get('EDGI_ZOOM_DELETE_AFTER_UPLO
 MEETINGS_TO_RECORD = ['EDGI Community Standup']
 DEFAULT_YOUTUBE_PLAYLIST = 'Uploads from Zoom'
 DEFAULT_YOUTUBE_CATEGORY = 'Science & Technology'
+DEFAULT_VIDEO_LICENSE = 'creativeCommon'
 
 client = ZoomClient(ZOOM_API_KEY, ZOOM_API_SECRET)
 
@@ -110,6 +111,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                             "--title=" + title,
                             "--playlist=" + DEFAULT_YOUTUBE_PLAYLIST,
                             "--category=" + DEFAULT_YOUTUBE_CATEGORY,
+                            "--license=" + DEFAULT_VIDEO_LICENSE,
                             "--recording-date=" + fix_date(meeting['start_time']),
                             "--privacy=unlisted",
                             "--client-secrets=client_secret.json",


### PR DESCRIPTION
Reticketed from https://github.com/edgi-govdata-archiving/edgi-scripts/pull/1#discussion_r128335181

There is a reference to a hardcoded fix through the link above. Anyone is welcome to help that along, but I'll get to it later if now.