### PR TITLE
Ensure that script doesn't freeze under rare pip-install prompt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            # When fetching package from new git repo, use (w)ipe action
+            pip install -r requirements.txt --exists-action w
 
       - save_cache:
           paths:


### PR DESCRIPTION
Fixing issues raised here: https://github.com/edgi-govdata-archiving/edgi-scripts/pull/31#issuecomment-369122489