### PR TITLE
Transpose Zoom transcript to be YouTube-friendly for deeplinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ directly to the spot in the video where the comment was made.
 **Usage**
 
 ```
-python scripts/convert_transcript_timestamps.py GMT20180412-150205_EDJ-Biweek.txt > transcript.txt
+python scripts/convert_transcript_timestamps.py --help
+python scripts/convert_transcript_timestamps.py transcript.txt > transposed-transcript.txt
 ```
 
 ### Zoom-to-YouTube Uploader: `upload_zoom_recordings.py` and `auth.py`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ the EDGI website are backed up to the Internet Archive.
 bash scripts/archive.sh envirodatagov.org
 ```
 
+### Convert Zoom timestamps for YouTube: `convert_transcript_timestamps.py`
+
+This script is used from the terminal to convert the Zoom chat
+transcript into a form that's friendly to post to YouTube video
+descriptions or comments. When the Zoom timestamps are shifted to
+account for when the recording started, then the timecodes will link
+directly to the spot in the video where the comment was made.
+
+**Usage**
+
+```
+python scripts/convert_transcript_timestamps.py GMT20180412-150205_EDJ-Biweek.txt > transcript.txt
+```
+
 ### Zoom-to-YouTube Uploader: `upload_zoom_recordings.py` and `auth.py`
 
 This script cycles through each Zoom cloud recording longer than 60

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 -e git://github.com/edgi-govdata-archiving/youtube-upload.git@add-license-option#egg=youtube-upload
 zoomus
+click

--- a/scripts/convert_transcript_timestamps.py
+++ b/scripts/convert_transcript_timestamps.py
@@ -33,7 +33,7 @@ def process(transcript_file):
     with open(transcript_file) as f:
         content = f.readlines()
     for line in content:
-        line_re = re.compile('^(?P<timestamp>.+?)\s+(?P<author>.+?): (?P<message>.+)')
+        line_re = re.compile('^(?P<timestamp>.+?)\s+(?P<author>.+?):\s+(?P<message>.+)')
         result = re.match(line_re, line)
         data = {}
         data.update({'ts': result.group('timestamp')})

--- a/scripts/convert_transcript_timestamps.py
+++ b/scripts/convert_transcript_timestamps.py
@@ -1,61 +1,56 @@
 #!/usr/bin/env python
-#
-# Description:
-#
-#      This script takes a transcript TXT from Zoom and converts it to a
-#      transcript for posting to YouTube.
-#
-# Usage:
-#
-#      python scripts/convert_transcript_timestamps.py <input transript txt> [ <relative start timestamp> ]
-#
-# Environment Variables:
-#
-#     None.
-#
-# Configuration:
-#
-#     None.
-
 import re
 from datetime import timedelta
 import sys
+import click
 
-arg_names = ['command', 'file', 'start_ts']
-args = dict(zip(arg_names, sys.argv))
-# TODO: start_ts not implemented
+OUT_TRANSCRIPT_LINE_TEMPLATE = '{ts} {author}: {msg}\n'
+IN_TRANSCRIPT_START_MARKER = 'START'
 
-# Number of seconds to shift the timestamps forward to ensure the context of
-# each comment is captured.
-SEC_TIMESHIFTED = 5
+@click.command()
+@click.argument('input-file', type=click.File('rb'))
+@click.option('--output-file', help='The file to write. Default: stdout', default='-', type=click.File('wb'))
+@click.option('--context-offset', help='The number of seconds to shift timestamps forward for message context. Default: 5', default=5)
+@click.option('--start-timestamp', help='The timestamp to manually set as the start. Default: auto-detects START message')
 
-def process(transcript_file):
-    with open(transcript_file) as f:
-        content = f.readlines()
-    for line in content:
-        line_re = re.compile('^(?P<timestamp>.+?)\s+(?P<author>.+?):\s+(?P<message>.+)')
-        result = re.match(line_re, line)
-        data = {}
-        data.update({'ts': result.group('timestamp')})
-        data.update({'author': result.group('author')})
-        data.update({'msg': result.group('message')})
+def process(input_file, output_file, context_offset, start_timestamp):
+    """This script takes a transcript TXT from Zoom and converts it to a
+    transcript for posting to YouTube."""
 
-        yield data
+    transcript_data = parse_transcript(input_file, context_offset)
+    for line in transcript_data:
+        updated_line = OUT_TRANSCRIPT_LINE_TEMPLATE.format(ts =line['ts_transposed'],
+                author=line['author'],
+                msg=line['msg'])
+        output_file.write(updated_line.encode('utf8'))
 
-is_start = lambda x: x.startswith('START')
+def parse_transcript(input_file, context_offset):
+    data = [{'raw': x.decode('utf8')} for x in input_file.readlines()]
+    line_re = re.compile('^(?P<timestamp>.+?)\s+(?P<author>.+?):\s+(?P<message>.+)')
 
-transcript = list(process(args['file']))
+    for i, line in enumerate(data):
+        result = re.match(line_re, line['raw'])
+        data[i].update({'ts': result.group('timestamp')})
+        data[i].update({'author': result.group('author')})
+        data[i].update({'msg': result.group('message')})
 
-def parse_ts_delta(timecode):
-    hh, mm, ss = [int(x) for x in timecode.split(':')]
+    is_start = lambda x: x['msg'].startswith(IN_TRANSCRIPT_START_MARKER)
+    recording_starts = list(filter(is_start, data))
+    start_delta = parse_ts_delta(recording_starts[0]['ts'])
+
+    for i, line in enumerate(data):
+        ts_transposed = parse_ts_delta(line['ts']) - start_delta
+        context_shift = timedelta(seconds=context_offset)
+        if ts_transposed > context_shift:
+            ts_transposed = ts_transposed - context_shift
+        ts_transposed = '0' + str(ts_transposed)
+        data[i].update({'ts_transposed': ts_transposed})
+
+    return data
+
+def parse_ts_delta(timestamp):
+    hh, mm, ss = [int(x) for x in timestamp.split(':')]
     return timedelta(hours=hh, minutes=mm, seconds=ss)
 
-recording_starts = [x for x in transcript if is_start(x['msg'])]
-start_delta = parse_ts_delta(recording_starts[0]['ts'])
-
-for line in transcript:
-    transposed_ts = parse_ts_delta(line['ts']) - start_delta
-    context_shift = timedelta(seconds=SEC_TIMESHIFTED)
-    if transposed_ts > context_shift:
-        transposed_ts = transposed_ts - context_shift
-    print('0{} {}: {}'.format(transposed_ts, line['author'], line['msg']))
+if __name__ == '__main__':
+    process()

--- a/scripts/convert_transcript_timestamps.py
+++ b/scripts/convert_transcript_timestamps.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
+import click
 import re
 from datetime import timedelta
-import sys
-import click
 
 OUT_TRANSCRIPT_LINE_TEMPLATE = '{ts} {author}: {msg}\n'
 IN_TRANSCRIPT_START_MARKER = 'START'

--- a/scripts/convert_transcript_timestamps.py
+++ b/scripts/convert_transcript_timestamps.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Description:
+#
+#      This script takes a transcript TXT from Zoom and converts it to a
+#      transcript for posting to YouTube.
+#
+# Usage:
+#
+#      python scripts/convert_transcript_timestamps.py <input transript txt> [ <relative start timestamp> ]
+#
+# Environment Variables:
+#
+#     None.
+#
+# Configuration:
+#
+#     None.
+
+import re
+from datetime import timedelta
+import sys
+
+arg_names = ['command', 'file', 'start_ts']
+args = dict(zip(arg_names, sys.argv))
+# TODO: start_ts not implemented
+
+# Number of seconds to shift the timestamps forward to ensure the context of
+# each comment is captured.
+SEC_TIMESHIFTED = 5
+
+def process(transcript_file):
+    with open(transcript_file) as f:
+        content = f.readlines()
+    for line in content:
+        line_re = re.compile('^(?P<timestamp>.+?)\s+(?P<author>.+?): (?P<message>.+)')
+        result = re.match(line_re, line)
+        data = {}
+        data.update({'ts': result.group('timestamp')})
+        data.update({'author': result.group('author')})
+        data.update({'msg': result.group('message')})
+
+        yield data
+
+is_start = lambda x: x.startswith('START')
+
+transcript = list(process(args['file']))
+
+def parse_ts_delta(timecode):
+    hh, mm, ss = [int(x) for x in timecode.split(':')]
+    return timedelta(hours=hh, minutes=mm, seconds=ss)
+
+recording_starts = [x for x in transcript if is_start(x['msg'])]
+start_delta = parse_ts_delta(recording_starts[0]['ts'])
+
+for line in transcript:
+    transposed_ts = parse_ts_delta(line['ts']) - start_delta
+    context_shift = timedelta(seconds=SEC_TIMESHIFTED)
+    if transposed_ts > context_shift:
+        transposed_ts = transposed_ts - context_shift
+    print('0{} {}: {}'.format(transposed_ts, line['author'], line['msg']))


### PR DESCRIPTION
Limited to scope of this issue from posting comment, to just transposing. Created new issue for posting: #34

----

Right now, chat logs need to be manually downloaded from Zoom. We should instead post them as a comment on each video archive.

Here are some comments -- :mag: facts, :heart: feelings, and :bulb: ideas -- related to this issue:

:mag: YouTube deeplinks relative timestamps in the format hh:mm:ss to spots in the video.
:mag: ~Zoom transcripts include GMT hour timestamps.~ [was mistaken]
:mag: Zoom transcript includes timestamps relative to start of meeting, not recording.
:mag: Zoom API includes GMT video start time.
:bulb: We can compute relative timestamp of each comment, and YouTube will deeplink to where it was posted in video.
:mag: The context of each comment will have come before, perhaps up to 30 seconds prior.
:bulb: We might want to off-set the timestamps so the deeplinks provide real context.

Call log format is (in GMT):

    hh:mm:ss\t<username>:\t<message>


cc: @lightandluck 