### PR TITLE
Adjust youtube upload interval to every 30 min instead of 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,8 @@ workflows:
       - build
     triggers:
       - schedule:
-          # Every 15 minutes
-          cron: "0,15,30,45 * * * *"
+          # Every 30 minutes
+          cron: "0,30 * * * *"
           filters:
             branches:
               only: master

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ seconds in duration and:
   * "Community Call"
 * **deletes** original video file from Zoom (**not** audio or chat log)
 
-This script is run every 15 minutes.
+This script is run every 30 minutes.
 
 Note: the script isn't smart enough to detect duplicate videos being
 uploaded more than once, but YouTube will recognize and disable them


### PR DESCRIPTION
We're hitting our CircleCI limits discussed [here](https://edgi.slack.com/archives/C57QL8M1T/p1535694176000100) in Slack. 

Hoping this will help alleviate some of that. Not entirely sure if these does everything needed to change the interval, so please fix if you know how!