### PR TITLE
hotfix: add oauth2client to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 -e git://github.com/edgi-govdata-archiving/youtube-upload.git@add-license-option#egg=youtube-upload
 zoomus
 click
+oauth2client


### PR DESCRIPTION
https://github.com/edgi-govdata-archiving/youtube-upload/pull/1 didn't work, so I'm trying to see if adding `oauth2client` to this repo directly will