### PR TITLE
Update youtube-upload cron job to run only M-F during the day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
     triggers:
       - schedule:
           # Every 30 minutes
-          cron: "0,30 * * * *"
+          cron: "0,30 7-19 * * 1-5"
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
     triggers:
       - schedule:
           # Every 30 minutes
-          cron: "0,30 7-19 * * 1-5"
+          cron: "0,30 * * * 1-5"
           filters:
             branches:
               only: master


### PR DESCRIPTION
Looks like we're hitting our free limit in CircleCI so reducing the period the youtube upload script runs to help reduce usage.