### PR TITLE
Log upload errors and minimize duplicate client creation

### DIFF
--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -31,7 +31,8 @@ import json
 import os
 import re
 import requests
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
+import sys
 import tempfile
 from urllib.parse import urlparse
 from zoomus import ZoomClient
@@ -136,7 +137,15 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                             ]
                     print('Adding to main playlist: Uploads from Zoom')
                     FNULL = open(os.devnull, 'w')
-                    video_id = check_output(command, stderr=FNULL).strip().decode('utf-8')
+                    try:
+                        video_id = check_output(command, stderr=FNULL).strip().decode('utf-8')
+                    except CalledProcessError as error:
+                        # Make sure we log what the script actually output!
+                        if error.output:
+                            print(f'Upload failed with message: {error.output}', file=sys.stderr)
+                        
+                        # But still stop execution afterward.
+                        raise
 
                     # TODO: we could use this client to upload the video,
                     # which would save on API calls if we have > 1 video.

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -26,6 +26,7 @@
 #     See README for how to generate these files.
 
 from datetime import datetime
+import functools
 import json
 import os
 import re
@@ -82,6 +83,17 @@ def download_file(url, download_path):
 
     return filepath
 
+@functools.lru_cache()
+def get_youtube_client():
+    yt_options = {
+        'client_secrets': 'client_secret.json',
+        'credentials_file': '.youtube-upload-credentials.json',
+        'auth_browser': None,
+    }
+    yt_options = SimpleNamespace(**yt_options)
+    youtube = main.get_youtube_handler(yt_options)
+    return youtube
+
 DO_FILTER = False
 
 with tempfile.TemporaryDirectory() as tmpdirname:
@@ -126,13 +138,9 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                     FNULL = open(os.devnull, 'w')
                     video_id = check_output(command, stderr=FNULL).strip().decode('utf-8')
 
-                    yt_options = {
-                            'client_secrets': 'client_secret.json',
-                            'credentials_file': '.youtube-upload-credentials.json',
-                            'auth_browser': None,
-                            }
-                    yt_options = SimpleNamespace(**yt_options)
-                    youtube = main.get_youtube_handler(yt_options)
+                    # TODO: we could use this client to upload the video,
+                    # which would save on API calls if we have > 1 video.
+                    youtube = get_youtube_client()
                     playlist_name = None
 
                     if any(x in meeting['topic'].lower() for x in ['web mon', 'website monitoring', 'wm']):


### PR DESCRIPTION
We previously created a new Youtube client (which involves some API calls for logging in, etc.) for every video we upload. This memoizes the creation of the client so we only ever make one, and only make it if we need it.

This is the clearest and smallest possible intervention I could see at a glance for reducing YouTube API calls. There seem to be other issues worth addressing in a different PR, though. (e.g. are videos not getting deleted?)