### PR TITLE
Don't set position for auto-sorted playlists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,28 +38,24 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
-      # TODO: re-enable this when we have the upload job fixed so it doesn't
-      # break with differently ordered playlists.
-      # - run:
-      #     name: run script
-      #     command: |
-      #       . venv/bin/activate
-      #       python3 scripts/upload_zoom_recordings.py
+      - run:
+          name: run script
+          command: |
+            . venv/bin/activate
+            python3 scripts/upload_zoom_recordings.py
 
 workflows:
   version: 2
   commit:
     jobs:
       - build
-  # TODO: re-enable this when we have the upload job fixed so it doesn't break
-  # with differently ordered playlists.
-  # youtube-upload:
-  #   jobs:
-  #     - build
-  #   triggers:
-  #     - schedule:
-  #         # Every 30 minutes
-  #         cron: "0,30 * * * 1-5"
-  #         filters:
-  #           branches:
-  #             only: master
+  youtube-upload:
+    jobs:
+      - build
+    triggers:
+      - schedule:
+          # Every 30 minutes
+          cron: "0,30 * * * 1-5"
+          filters:
+            branches:
+              only: master

--- a/scripts/playlists.py
+++ b/scripts/playlists.py
@@ -1,9 +1,38 @@
+import googleapiclient
+import json
 import locale
 import sys
 
 def debug(obj, fd=sys.stderr):
     """Write obj to standard error."""
     print(obj, file=fd)
+
+def parse_youtube_http_error(error):
+    """
+    HTTP errors (class `googleapiclient.errors.HttpError`) unfortunately don't
+    make their details available in any useful way (!), so we have to do some
+    parsing here.
+
+    See how the error class handles parsing here:
+    https://github.com/googleapis/google-api-python-client/blob/41144858a766d2a2216af3aaa94c4aa7cd6fbe30/googleapiclient/errors.py#L47-L67
+    
+    Oddly, it doesn't match up with the format of YouTube errors here:
+    https://developers.google.com/youtube/v3/docs/core_errors
+
+    ¯\_(ツ)_/¯
+    """
+    try:
+        data = json.loads(error.content.decode("utf-8"))["error"]
+        # Ensure every error has `domain`, `reason`, `message`, and `code`. (They
+        # should, but just in case...)
+        for error in data["errors"]:
+            error.setdefault("domain", "")
+            error.setdefault("reason", "")
+            error.setdefault("message", "")
+            error.setdefault("code", data["code"])
+        return data
+    except (ValueError, KeyError, TypeError):
+        return None
 
 # TODO: Place playlist_id of PUBLIC playlists into constants.py instead of looking up in youtube
 # because that eats some of our quota credits. Probably put playlist_id of unlisted playlists
@@ -39,7 +68,8 @@ def create_playlist(youtube, title, privacy):
 def add_video_to_existing_playlist(youtube, playlist_id, video_id):
     """Add video to playlist (by identifier) and return the playlist ID."""
     debug("Adding video to playlist: {0}".format(playlist_id))
-    return youtube.playlistItems().insert(part="snippet", body={
+
+    body = {
         "snippet": {
             "playlistId": playlist_id,
             "position": 0,
@@ -48,8 +78,24 @@ def add_video_to_existing_playlist(youtube, playlist_id, video_id):
                 "videoId": video_id,
             }
         }
-    }).execute()
-    
+    }
+
+    try:
+        return youtube.playlistItems().insert(part="snippet",
+                                              body=body).execute()
+    except googleapiclient.errors.HttpError as error:
+        parsed = parse_youtube_http_error(error)
+        # A "manualSortRequired" error means the playlist is not manually
+        # sorted, and it needs to be in order to use "position". So just try
+        # again without setting "position" this time. (It's dumb, but the API
+        # appears to provide no way to test for this ahead of time.)
+        if parsed and any(error["reason"] == "manualSortRequired" for error in parsed["errors"]):
+            del body["snippet"]["position"]
+            return youtube.playlistItems().insert(part="snippet",
+                                                  body=body).execute()
+        else:
+            raise
+
 def add_video_to_playlist(youtube, video_id, title, privacy="unlisted"):
     """Add video to playlist (by title) and return the full response."""
     playlist_id = get_playlist(youtube, title) or \


### PR DESCRIPTION
The YouTube API requires you to set the `position` when adding videos to manually sorted playlists, but also requires you *not* to set the `position` when adding to non-manually sorted playlists. This has been causing us a lot of heartache recently when playlists have had their sorting changed.

Unfortunately, you can't detect a playlist's sorting from the API, so the approach here is to set `position`, then fall back to not setting it if we got a `manualSortRequired` error. This also has some funky parsing code since the Google API client doesn't give us back the actual `manualSortRequired` info in its error object.

**NOTE: this is ready for review, but I’ve left it in “draft” status because the CircleCI config should be changed to re-enable to upload script before merging.**