### PR TITLE
Security: upgrade httplib2 (CVE-2020-11078)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ google-api-python-client ~=1.7.11
 google-auth ~=1.11.2
 google-auth-oauthlib ~=0.4.1
 google-auth-httplib2 ~=0.0.3
-httplib2 ~=0.17.0
+httplib2 ~=0.18.1


### PR DESCRIPTION
This resolves CVE-2020-11078 (https://github.com/advisories/GHSA-gg84-qgv9-w4pq) by updating our version of `httplib2`. It should still be compatible with our usage.

While fixing this, I noticed several other dependencies are out of date or totally deprecated, so also filed #61.