### PR TITLE
Update zoom api to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,11 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
       
-      # TODO - reenable
-      # - run:
-      #     name: run script
-      #     command: |
-      #       . venv/bin/activate
-      #       python3 scripts/upload_zoom_recordings.py
+      - run:
+          name: run script
+          command: |
+            . venv/bin/activate
+            python3 scripts/upload_zoom_recordings.py
 
 workflows:
   version: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-zoomus
+zoomus ~=1.1.3
 click
 oauth2client
 google-api-python-client ~=1.7.11

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -163,11 +163,11 @@ def main():
                     url = f'https://api.zoom.us/v2/meetings/{file["meeting_id"]}/recordings/{file["id"]}'
                     querystring = {"action":"trash"}
                     headers = {'authorization': f'Bearer {client.config["token"]}'}
-                    resp = requests.request("DELETE", url, headers=headers, params=querystring)
-                    if resp.status_code == 204:
+                    response = requests.request("DELETE", url, headers=headers, params=querystring)
+                    if response.status_code == 204:
                         print(f'  Deleted {file["file_type"]} file from Zoom for recording: {meeting["topic"]}')
                     else:
-                        print(f'  The file could not be deleted. We received this response: {resp.status_code}. Please check https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingdeleteone for what that could mean.')
+                        print(f'  The file could not be deleted. We received this response: {response.status_code}. Please check https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingdeleteone for what that could mean.')
                     
 
 if __name__ == '__main__':

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -167,7 +167,7 @@ def main():
                     if resp.status_code == 204:
                         print(f'  Deleted {file["file_type"]} file from Zoom for recording: {meeting["topic"]}')
                     else:
-                        print(f'  The file could not be deleted. We received this response: {resp.status_code}')
+                        print(f'  The file could not be deleted. We received this response: {resp.status_code}. Please check https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingdeleteone for what that could mean.')
                     
 
 if __name__ == '__main__':


### PR DESCRIPTION
Looks like Zoom finally deprecated their v1 API, because we were getting 403 responses from it. In any case, we should migrate to v2.

This PR makes sure we use an up-to-date package of zoomus, use the default v2 API, and uses the zoom API directly to delete recordings instead of zoomus, because zoomus only implements deleting all recorded files related to the meeting using the v2 API, while we still want to retain the audio and chat files for backup. 