### PR TITLE
Update to currently supported CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.2
+      - image: cimg/python:3.10
     environment:
       - EDGI_ZOOM_DELETE_AFTER_UPLOAD: '1'
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-git+git://github.com/lightandluck/zoomus.git
+git+https://github.com/lightandluck/zoomus.git
 click
 oauth2client
 google-api-python-client ~=1.7.11


### PR DESCRIPTION
I noticed a lot of jobs hanging and/or actively failing (which I think are fouling up CircleCI runs for other repositories, too), and one issue is that this repo is still using an image that is not just deprecated but actually not supported at all by CircleCI. There might be other problems, but this at least is easily solvable.