### PR TITLE
Schedule uploads on GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,10 @@ workflows:
       - build
     triggers:
       - schedule:
-          # Every hour at :10
-          cron: "10 * * * 1-5"
+          # Every hour in the afternoon at :10 on weekdays
+          # (This is only in the afternoon so we can compare how this is doing
+          # vs. how GitHub Actions is doing and then maybe turn off Circle.)
+          cron: "10 13-23 * * 1-5"
           filters:
             branches:
               only: main

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -1,0 +1,47 @@
+name: Upload Zoom Recordings to YouTube
+
+on:
+  schedule:
+    # 10 minutes after every hour before noon on weekdays
+    # TODO: when we are ready to switch off Circle, run every hour instead of
+    # just in the morning.
+    - cron: "10 0-12 * * 1-5"
+
+  workflow_dispatch: {}
+
+  # XXX: This is for testing; do not merge
+  pull_request: {}
+
+jobs:
+  zoom_to_youtube:
+    name: Upload Zoom to YouTube
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+      
+      - name: Decrypt Credential Files
+        env:
+          EDGI_ZOOM_API_SECRET: ${{ secrets.EDGI_ZOOM_API_SECRET }}
+        run: |
+          openssl aes-256-cbc -k "$EDGI_ZOOM_API_SECRET" -in client_secret.json.enc -out client_secret.json -d -md sha256
+          openssl aes-256-cbc -k "$EDGI_ZOOM_API_SECRET" -in .youtube-upload-credentials.json.enc -out .youtube-upload-credentials.json -d -md sha256
+
+      - name: Upload
+        env:
+          EDGI_ZOOM_DELETE_AFTER_UPLOAD: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
+          EDGI_ZOOM_API_KEY: ${{ secrets.EDGI_ZOOM_API_KEY }}
+          EDGI_ZOOM_API_SECRET: ${{ secrets.EDGI_ZOOM_API_SECRET }}
+          DEFAULT_YOUTUBE_PLAYLIST: ${{ secrets.DEFAULT_YOUTUBE_PLAYLIST }}
+        run: |
+          echo "Delete after upload? ${EDGI_ZOOM_DELETE_AFTER_UPLOAD}"
+          # python3 scripts/upload_zoom_recordings.py

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -7,9 +7,13 @@ on:
     # just in the morning.
     - cron: "10 0-12 * * 1-5"
 
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      delete_after_upload:
+        description: 'Delete recordings from Zoom after uploading to YouTube'
+        type: boolean
+        default: true
 
-  # XXX: This is for testing; do not merge
   pull_request: {}
 
 jobs:
@@ -18,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install Dependencies
@@ -38,9 +42,10 @@ jobs:
 
       - name: Upload
         env:
-          EDGI_ZOOM_DELETE_AFTER_UPLOAD: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
-          EDGI_ZOOM_API_KEY: ${{ secrets.EDGI_ZOOM_API_KEY }}
-          EDGI_ZOOM_API_SECRET: ${{ secrets.EDGI_ZOOM_API_SECRET }}
+          EDGI_ZOOM_DELETE_AFTER_UPLOAD: ${{ github.event_name == 'schedule' || inputs.delete_after_upload }}
           DEFAULT_YOUTUBE_PLAYLIST: ${{ secrets.DEFAULT_YOUTUBE_PLAYLIST }}
+          EDGI_ZOOM_ACCOUNT_ID: ${{ secrets.EDGI_ZOOM_ACCOUNT_ID }}
+          EDGI_ZOOM_CLIENT_ID: ${{ secrets.EDGI_ZOOM_CLIENT_ID }}
+          EDGI_ZOOM_CLIENT_SECRET: ${{ secrets.EDGI_ZOOM_CLIENT_SECRET }}
         run: |
           python3 scripts/upload_zoom_recordings.py

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
           cache: 'pip'
 
       - name: Install Dependencies

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -43,5 +43,4 @@ jobs:
           EDGI_ZOOM_API_SECRET: ${{ secrets.EDGI_ZOOM_API_SECRET }}
           DEFAULT_YOUTUBE_PLAYLIST: ${{ secrets.DEFAULT_YOUTUBE_PLAYLIST }}
         run: |
-          echo "Delete after upload? ${EDGI_ZOOM_DELETE_AFTER_UPLOAD}"
-          # python3 scripts/upload_zoom_recordings.py
+          python3 scripts/upload_zoom_recordings.py


### PR DESCRIPTION
This is a first pass at running the upload workflow on GitHub Actions alongside/instead of CircleCI. @jerryedgi you’ll probably want to take a look and make any relevant changes before merging.

My thinking here is that I’ve scheduled this for half the day and CircleCI for half the day, so we can run them side-by-side for a bit if we want, and then turn one or the other off.