### PR TITLE
HOTFIX: Clear cache in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v2-dependencies-{{ checksum "requirements.txt" }}
+          - v2-dependencies-
 
       - run:
           name: install dependencies
@@ -36,7 +37,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}
       
       - run:
           name: run script


### PR DESCRIPTION
Update to a new cache key. Jobs have been failing, and it looks like it’s because the Python in the image has updated but the virtual environment that is cached has not (because it’s cached).