### PR TITLE
Cache Pip data, not virtualenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
 
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}
-          - v2-dependencies-
+          - v1-pip-{{ checksum "requirements.txt" }}
+          - v1-pip-
 
       - run:
           name: install dependencies
@@ -36,8 +36,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ./venv
-          key: v2-dependencies-{{ checksum "requirements.txt" }}
+            - ~/.cache/pip
+          key: v1-pip-{{ checksum "requirements.txt" }}
       
       - run:
           name: run script


### PR DESCRIPTION
Caching the whole virtual environment is nice and speedy, but can occasionally result in issues when the base image is updated (e.g. #68). Just caching Pip's cache should work a little more reliably.