### PR TITLE
Run GitHub Actions full time, disable CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,16 +61,21 @@ workflows:
       - upload-zoom-recordings:
           delete_after_upload: false
           dry_run: true
-  youtube-upload:
-    jobs:
-      - upload-zoom-recordings:
-          delete_after_upload: true
-    triggers:
-      - schedule:
-          # Every hour in the afternoon at :10 on weekdays
-          # (This is only in the afternoon so we can compare how this is doing
-          # vs. how GitHub Actions is doing and then maybe turn off Circle.)
-          cron: "10 13-23 * * 1-5"
-          filters:
-            branches:
-              only: main
+
+  # FIXME: This script is temporarily disabled in CircleCI. Once we are
+  # confident it's doing the job reliably on GitHub, delete this whole
+  # CircleCI config file.
+  #
+  # youtube-upload:
+  #   jobs:
+  #     - upload-zoom-recordings:
+  #         delete_after_upload: true
+  #   triggers:
+  #     - schedule:
+  #         # Every hour in the afternoon at :10 on weekdays
+  #         # (This is only in the afternoon so we can compare how this is doing
+  #         # vs. how GitHub Actions is doing and then maybe turn off Circle.)
+  #         cron: "10 13-23 * * 1-5"
+  #         filters:
+  #           branches:
+  #             only: main

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -2,10 +2,8 @@ name: Upload Zoom Recordings to YouTube
 
 on:
   schedule:
-    # 10 minutes after every hour before noon on weekdays
-    # TODO: when we are ready to switch off Circle, run every hour instead of
-    # just in the morning.
-    - cron: "10 0-12 * * 1-5"
+    # 10 minutes after every hour on weekdays
+    - cron: "10 * * * 1-5"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
We'll check back in to make sure this is working well in a week or so, and then delete the CircleCI config entirely.