### PR TITLE
Add a nice wrapper for zoomus

### DIFF
--- a/scripts/lib/zoom.py
+++ b/scripts/lib/zoom.py
@@ -1,0 +1,102 @@
+from typing import Dict
+from functools import wraps
+from requests import Response
+from zoomus import ZoomClient
+
+
+ZOOM_DOCS_URL = 'https://developers.zoom.us/docs/api/'
+
+
+class ZoomError(Exception):
+    response: Response
+    data: Dict
+    code: int = 0
+    message: str
+
+    def __init__(self, response, message=None):
+        self.response = response
+        try:
+            self.data = response.json()
+        except Exception:
+            self.data = {}
+
+        self.message = message or self.data.pop('message', 'Zoom API error')
+        self.code = self.data.pop('code')
+        super().__init__(
+            f'{self.message} (code={self.code}, http_status={self.response.status_code}) '
+            f'Check the docs for details: {ZOOM_DOCS_URL}.'
+        )
+
+
+class ZoomResponse:
+    response: Response
+    _data: Dict = None
+
+    def __init__(self, response: Response):
+        self.response = response
+
+    def __getitem__(self, name):
+        return self.data[name]
+
+    @property
+    def data(self):
+        if self._data is None:
+            self._data = self.response.json()
+
+        return self._data
+
+    @property
+    def text(self):
+        return self.response.text
+
+
+def wrap_method_with_parsing(original):
+    @wraps(original)
+    def wrapper(*args, **kwargs):
+        result = original(*args, **kwargs)
+        if isinstance(result, Response):
+            if result.status_code >= 400:
+                raise ZoomError(result)
+            else:
+                return ZoomResponse(result)
+        else:
+            return result
+
+    return wrapper
+
+
+def wrap_component_with_parsing(component):
+    for name in dir(component):
+        if not name.startswith('_'):
+            original = getattr(component, name)
+            if callable(original):
+                setattr(component, name, wrap_method_with_parsing(original))
+
+
+class FancyZoom(ZoomClient):
+    """
+    Wraps a zoomus ZoomClient so that nice exception objects are raised for bad
+    responses and good JSON responses are pre-parsed.
+
+    Examples
+    --------
+    >>> instance = FancyZoon(CLIENT_ID, CLIENT_SECRET, ACCOUNT_ID)
+
+    Get a user by ID. The response data is readily available:
+
+    >>> instance.user.get(id='abc123')['id'] == 'abc123'
+
+    Raises an exception for errors instead of returning a response object:
+
+    >>> try:
+    >>>     client.user.get(id='bad_id')
+    >>> except ZoomError as error:
+    >>>     error.response.status_code == 404
+    >>>     error.code == 1001
+    >>>     error.message == 'User does not exist: bad_id'
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for component in self.components.values():
+            wrap_component_with_parsing(component)

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -188,7 +188,7 @@ def save_to_youtube(youtube, meeting: dict, filepath: str, dry_run: bool) -> Non
 
 
 def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
-                   zoom_client: ZoomClient, tempdir: str) -> None:
+                   zoom_client: FancyZoom, tempdir: str) -> None:
     recording_date = dateutil.parser.isoparse(meeting['start_time'])
 
     with open('gdrive-locations.json') as file:

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -260,7 +260,7 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
             if not media_type:
                 raise ValueError(f'No known media type for file extension "{extension}"')
 
-            filepath = download_zoom_file(zoom_client, download_url, tempdir)
+            filepath = zoom_client.download_file(download_url, tempdir)
             print(f'    Uploading {filepath}\n      {upload_name=}')
             if not dry_run:
                 file_info = {'name': upload_name, 'parents': [meeting_folder]}


### PR DESCRIPTION
I might be getting overcomplicated here. In #73, I added a bunch of error handling code for Zoom, but it felt kind of awkward. I reworked that here into a `FancyZoom` class. You use it just like `zoomus.ZoomClient`, except the API calls return parsed data on success and raise exceptions on error.

No need to explicitly parse:

```python
# Previously:
zoom.user.get(id='abc123').json()['id']

# Now:
zoom.user.get(id='abc123')['id']
```

No need to check and handle error statuses with lots of extra conditions:

```python
# Previously:
response = zoom.user.get(id='bad_id')
if response.status_code >= 400:
    # Do something indicating the error

# Now:
zoom.user.get(id='bad_id')  # raises `ZoomError` with a nice message
```

This also moves file downloading into the new class, since it makes more sense there.