### PR TITLE
Always set a time range

### DIFF
--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -15,6 +15,14 @@ on:
         description: 'Dry run: report planned work, but do not actually upload or change anything'
         type: boolean
         default: false
+      from:
+        description: 'Look for recordings after this date/time'
+        type: string
+        default: ''
+      to:
+        description: 'Look for recordings after this date/time'
+        type: string
+        default: ''
 
   pull_request: {}
 
@@ -56,4 +64,6 @@ jobs:
           EDGI_ZOOM_CLIENT_ID: ${{ secrets.EDGI_ZOOM_CLIENT_ID }}
           EDGI_ZOOM_CLIENT_SECRET: ${{ secrets.EDGI_ZOOM_CLIENT_SECRET }}
         run: |
-          python3 scripts/upload_zoom_recordings.py
+          python3 scripts/upload_zoom_recordings.py \
+            --from '${{ inputs.from }}' \
+            --to '${{ inputs.to }}'

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -18,11 +18,11 @@ on:
       from:
         description: 'Look for recordings after this date/time'
         type: string
-        default: ''
+        default: '5d'
       to:
-        description: 'Look for recordings after this date/time'
+        description: 'Look for recordings before this date/time'
         type: string
-        default: ''
+        default: '+1d'
 
   pull_request: {}
 

--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -18,11 +18,11 @@ on:
       from:
         description: 'Look for recordings after this date/time'
         type: string
-        default: '5d'
+        default: ''
       to:
         description: 'Look for recordings before this date/time'
         type: string
-        default: '+1d'
+        default: ''
 
   pull_request: {}
 
@@ -65,5 +65,5 @@ jobs:
           EDGI_ZOOM_CLIENT_SECRET: ${{ secrets.EDGI_ZOOM_CLIENT_SECRET }}
         run: |
           python3 scripts/upload_zoom_recordings.py \
-            --from '${{ inputs.from }}' \
-            --to '${{ inputs.to }}'
+            --from '${{ inputs.from || '5d' }}' \
+            --to '${{ inputs.to || '+1d' }}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google-api-python-client ~=2.141.0
 google-auth ~=2.34.0
 google-auth-oauthlib ~=1.2.1
 httplib2 ~=0.22.0
+python-dateutil ~=2.9.0


### PR DESCRIPTION
It looks like the Zoom API has removed the default time range, so we stopped seeing videos that needed uploading. This makes sure to always set one, and adds actual CLI argument parsing to support them.