### PR TITLE
Extract logic around ensuring a folder exists

### DIFF
--- a/scripts/lib/gdrive.py
+++ b/scripts/lib/gdrive.py
@@ -1,16 +1,5 @@
-import http.client as httplib
-import httplib2
-import os
-import random
-import time
-import json
-import locale
-import sys
-
-import google.oauth2.credentials
-from googleapiclient.discovery import build, build_from_document
-from googleapiclient.errors import HttpError, UnknownApiNameOrVersion
-from googleapiclient.http import MediaFileUpload
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
 from google.auth.exceptions import GoogleAuthError
 
 
@@ -24,10 +13,12 @@ DEFAULT_CREDENTIALS_FILE = '.gdrive-upload-credentials.json'
 API_SERVICE_NAME = 'drive'
 API_VERSION = 'v3'
 
+FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
+
 
 # Create client from stored authorization credentials.
 def get_gdrive_client(credentials_path: str = DEFAULT_CREDENTIALS_FILE):
-    credentials = google.oauth2.credentials.Credentials.from_authorized_user_file(credentials_path)
+    credentials = Credentials.from_authorized_user_file(credentials_path)
     return build(API_SERVICE_NAME, API_VERSION, credentials=credentials)
 
 
@@ -45,3 +36,26 @@ def validate_gdrive_credentials(client) -> bool:
         return True
     except GoogleAuthError:
         return False
+
+
+def ensure_folder(client, parent: str, name: str) -> str:
+    """
+    Create a folder with the given name if it does not exist. Returns the
+    folder's ID.
+    """
+    # You can't just list a folder's files -- there is only search.
+    # Docs: https://developers.google.com/drive/api/guides/search-files
+    found = client.files().list(
+        q=f"'{parent}' in parents and mimeType = '{FOLDER_MIME_TYPE}' and name = '{name}' and trashed = false",
+        fields="nextPageToken, files(id, name)",
+    ).execute()
+    if len(found['files']):
+        return found['files'][0]['id']
+
+    info = {
+        'name': name,
+        'mimeType': FOLDER_MIME_TYPE,
+        'parents': [parent],
+    }
+    subfolder = client.files().create(body=info, fields="id").execute()
+    return subfolder['id']

--- a/scripts/lib/gdrive.py
+++ b/scripts/lib/gdrive.py
@@ -59,3 +59,13 @@ def ensure_folder(client, parent: str, name: str) -> str:
     }
     subfolder = client.files().create(body=info, fields="id").execute()
     return subfolder['id']
+
+
+def is_trashed(client, file_id: str) -> bool:
+    """
+    Determine if a file/folder is in the trash.
+    There is a weird edge case this does *not* account for: if a file is added
+    to a folder *after* the folder was put in the trash, the file is not marked
+    as trashed (even though it effectivly is... I think).
+    """
+    return client.files().get(fileId=file_id, fields='id, trashed')['trashed']

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -42,7 +42,7 @@ from zoomus import ZoomClient
 from zoomus.util import encode_uuid
 from lib.constants import MEDIA_TYPE_FOR_EXTENSION, VIDEO_CATEGORY_IDS, ZOOM_ROLES
 from lib.youtube import get_youtube_client, upload_video, add_video_to_playlist, validate_youtube_credentials
-from lib.gdrive import get_gdrive_client, validate_gdrive_credentials, ensure_folder
+from lib.gdrive import get_gdrive_client, validate_gdrive_credentials, ensure_folder, is_trashed
 
 ZOOM_CLIENT_ID = os.environ['EDGI_ZOOM_CLIENT_ID']
 ZOOM_CLIENT_SECRET = os.environ['EDGI_ZOOM_CLIENT_SECRET']
@@ -258,6 +258,9 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
         location = location_options['default']
 
     folder_id = location['folder']
+    if is_trashed(client, folder_id):
+        raise RuntimeError(f'Cannot upload to GDrive folder "{folder_id}"; it is in the trash!')
+
     if location['subfolder_pattern']:
         subfolder_name = location['subfolder_pattern'].format(year=recording_date.year)
         if not dry_run:


### PR DESCRIPTION
This pulls out some the logic around ensuring a folder exists in Google Drive (i.e. the equivalent of `mkdir -p`) into a separate function for clarity. It also fixes some edge cases I discovered around trash.