### PR TITLE
Use awalsh128/cache-apt-pkgs-action for system deps

### DIFF
--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -33,9 +33,10 @@ jobs:
 
     steps:
       - name: Install ffmpeg
-        run: |
-          sudo apt-get update
-          sudo apt-get install ffmpeg
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ffmpeg
+          version: 1.0
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Most of the runtime of our Zoom upload workflow is spent installing ffmpeg from apt (except when there are a bunch of videos). Using `awalsh128/cache-apt-pkgs-action` adds some caching to the mix, which should make that much faster.