### PR TITLE
Properly support GDrive shared drives

### DIFF
--- a/scripts/lib/gdrive.py
+++ b/scripts/lib/gdrive.py
@@ -48,6 +48,8 @@ def ensure_folder(client, parent: str, name: str) -> str:
     found = client.files().list(
         q=f"'{parent}' in parents and mimeType = '{FOLDER_MIME_TYPE}' and name = '{name}' and trashed = false",
         fields="nextPageToken, files(id, name)",
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
     ).execute()
     if len(found['files']):
         return found['files'][0]['id']
@@ -57,7 +59,11 @@ def ensure_folder(client, parent: str, name: str) -> str:
         'mimeType': FOLDER_MIME_TYPE,
         'parents': [parent],
     }
-    subfolder = client.files().create(body=info, fields="id").execute()
+    subfolder = client.files().create(
+        body=info,
+        fields="id",
+        supportsAllDrives=True,
+    ).execute()
     return subfolder['id']
 
 
@@ -68,4 +74,8 @@ def is_trashed(client, file_id: str) -> bool:
     to a folder *after* the folder was put in the trash, the file is not marked
     as trashed (even though it effectivly is... I think).
     """
-    return client.files().get(fileId=file_id, fields='id, trashed').execute()['trashed']
+    return client.files().get(
+        fileId=file_id,
+        fields='id, trashed',
+        supportsAllDrives=True
+    ).execute()['trashed']

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -283,7 +283,12 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
         media = MediaFileUpload(filepath, mimetype='video/mp4', resumable=True)
         file = (
             client.files()
-            .create(body=file_info, media_body=media, fields="id")
+            .create(
+                body=file_info,
+                media_body=media,
+                fields="id",
+                supportsAllDrives=True
+            )
             .execute()
         )
 
@@ -320,7 +325,12 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
                 media = MediaFileUpload(filepath, mimetype=media_type, resumable=True)
                 file = (
                     client.files()
-                    .create(body=file_info, media_body=media, fields="id")
+                    .create(
+                        body=file_info,
+                        media_body=media,
+                        fields="id",
+                        supportsAllDrives=True,
+                    )
                     .execute()
                 )
 

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -37,12 +37,11 @@ import sys
 import tempfile
 from typing import Dict
 from urllib.parse import urlsplit
-from googleapiclient.http import MediaFileUpload
 from zoomus import ZoomClient
 from zoomus.util import encode_uuid
 from lib.constants import MEDIA_TYPE_FOR_EXTENSION, VIDEO_CATEGORY_IDS, ZOOM_ROLES
 from lib.youtube import get_youtube_client, upload_video, add_video_to_playlist, validate_youtube_credentials
-from lib.gdrive import get_gdrive_client, validate_gdrive_credentials, ensure_folder, is_trashed
+from lib.gdrive import get_gdrive_client, validate_gdrive_credentials, ensure_folder, is_trashed, upload_file
 
 ZOOM_CLIENT_ID = os.environ['EDGI_ZOOM_CLIENT_ID']
 ZOOM_CLIENT_SECRET = os.environ['EDGI_ZOOM_CLIENT_SECRET']
@@ -276,27 +275,18 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
     upload_name = f'{meeting_name}.mp4'
     print(f'    Uploading {filepath}\n      {upload_name=}')
     if not dry_run:
-        # TODO: improve resumability by following the suggestions around error
-        # handling at the end of this doc:
-        # https://github.com/googleapis/google-api-python-client/blob/main/docs/media.md
-        file_info = {'name': f'{meeting_name}.mp4', 'parents': [meeting_folder]}
-        media = MediaFileUpload(filepath, mimetype='video/mp4', resumable=True)
-        file = (
-            client.files()
-            .create(
-                body=file_info,
-                media_body=media,
-                fields="id",
-                supportsAllDrives=True
-            )
-            .execute()
+        upload_file(
+            client,
+            filepath,
+            folder_id=meeting_folder,
+            name=f'{meeting_name}.mp4',
+            media_type='video/mp4',
         )
 
     for file in meeting['recording_files']:
         download_url = file['download_url']
         extension = file['file_extension'].lower()
         upload_name = None
-        file_info = None
         match file['file_type'].lower():
             case 'mp4':
                 # We are already handling this file; nothing to do here.
@@ -314,6 +304,9 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
                 continue
 
         if upload_name:
+            # TODO: The upload command can guess based on file extension; it
+            # does the right thing for all but ".m4a", and maybe that's OK
+            # enough. Consider dropping this.
             media_type = MEDIA_TYPE_FOR_EXTENSION.get(extension)
             if not media_type:
                 raise ValueError(f'No known media type for file extension "{extension}"')
@@ -321,17 +314,12 @@ def save_to_gdrive(client, meeting: dict, filepath: str, dry_run: bool,
             filepath = download_zoom_file(zoom_client, download_url, tempdir)
             print(f'    Uploading {filepath}\n      {upload_name=}')
             if not dry_run:
-                file_info = {'name': upload_name, 'parents': [meeting_folder]}
-                media = MediaFileUpload(filepath, mimetype=media_type, resumable=True)
-                file = (
-                    client.files()
-                    .create(
-                        body=file_info,
-                        media_body=media,
-                        fields="id",
-                        supportsAllDrives=True,
-                    )
-                    .execute()
+                upload_file(
+                    client,
+                    filepath,
+                    folder_id=meeting_folder,
+                    name=upload_name,
+                    media_type=media_type,
                 )
 
 


### PR DESCRIPTION
It turns out we have to set a few extra options in order to work with shared drives. Test runs were working fine after the switch to a shared drive, but it turns out that's because we didn't make any calls that required special options until we actually had a video to upload (some commands silently fail and just return no results). Everything mostly worked fine until we had a meeting to upload, and then it started failing because of this.

More info: https://developers.google.com/workspace/drive/api/guides/enable-shareddrives