### PR TITLE
Put the upload scripts output in the job summary

### DIFF
--- a/.github/workflows/zoom-upload.yml
+++ b/.github/workflows/zoom-upload.yml
@@ -69,4 +69,13 @@ jobs:
         run: |
           python3 scripts/upload_zoom_recordings.py \
             --from '${{ inputs.from || '5d' }}' \
-            --to '${{ inputs.to || '+1d' }}'
+            --to '${{ inputs.to || '+1d' }}' \
+            | tee output.txt
+
+          (
+            echo '# Upload Output'
+            echo ''
+            echo '```'
+            cat output.txt
+            echo '```'
+          ) >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
This makes the results and work the script did a little more obviously visible when looking at a workflow run in the actions panel, instead of needing to click several levels deep to expose information about what happened.