### PR TITLE
Extract Zoom utilities to separate module

### DIFF
--- a/scripts/lib/constants.py
+++ b/scripts/lib/constants.py
@@ -4,12 +4,6 @@ USER_TYPES = {
     'corp': 3,
 }
 
-ZOOM_ROLES = {
-    'owner': 0,
-    'admin': 1,
-    'member': 2,
-}
-
 VIDEO_CATEGORY_IDS = {
     'Film & Animation': 1,
     'Autos & Vehicles': 2,

--- a/scripts/lib/constants.py
+++ b/scripts/lib/constants.py
@@ -1,9 +1,3 @@
-USER_TYPES = {
-    'basic': 1,
-    'pro': 2,
-    'corp': 3,
-}
-
 VIDEO_CATEGORY_IDS = {
     'Film & Animation': 1,
     'Autos & Vehicles': 2,

--- a/scripts/lib/zoom.py
+++ b/scripts/lib/zoom.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum, StrEnum, auto
 import os.path
 import requests
 from requests import Response
@@ -23,6 +23,16 @@ class RecordingStatus(Enum):
                 return RecordingStatus.PROCESSING
 
         return RecordingStatus.READY
+
+
+class ZoomRole(StrEnum):
+    """
+    Built-in user roles for Zoom. Accounts can also have custom roles with
+    more complex ID strings that are not listed here.
+    """
+    OWNER = '0'
+    ADMIN = '1'
+    MEMBER = '2'
 
 
 class ZoomError(Exception):

--- a/scripts/lib/zoom.py
+++ b/scripts/lib/zoom.py
@@ -1,0 +1,83 @@
+from enum import Enum, auto
+import os.path
+import requests
+from requests import Response
+from zoomus import ZoomClient
+from urllib.parse import urlsplit
+
+
+ZOOM_DOCS_URL = 'https://developers.zoom.us/docs/api/'
+
+
+class RecordingStatus(Enum):
+    ONGOING = auto()
+    PROCESSING = auto()
+    READY = auto()
+
+    @staticmethod
+    def from_meeting(meeting: dict) -> 'RecordingStatus':
+        for file in meeting['recording_files']:
+            if file['recording_end'] == '':
+                return RecordingStatus.ONGOING
+            elif file['status'] != 'completed':
+                return RecordingStatus.PROCESSING
+
+        return RecordingStatus.READY
+
+
+class ZoomError(Exception):
+    response: Response
+    data: dict
+    code: int = 0
+    message: str
+
+    def __init__(self, response: Response, message: str | None = None):
+        self.response = response
+        try:
+            self.data = response.json()
+        except Exception:
+            self.data = {}
+
+        self.message = message or self.data.pop('message', 'Zoom API error')
+        self.code = self.data.pop('code', 0)
+        super().__init__(
+            f'{self.message} '
+            f'(code={self.code}, http_status={self.response.status_code}) '
+            f'Check the docs for details: {ZOOM_DOCS_URL}.'
+        )
+
+
+def raise_for_status(response: Response) -> None:
+    """Raise ``ZoomError`` if the response has a bad status code."""
+    if response.status_code >= 400:
+        raise ZoomError(response)
+
+
+def parse_zoom(response: Response) -> dict:
+    """Parse a response from the Zoom API as a dict or raise ``ZoomError``."""
+    raise_for_status(response)
+    return response.json()
+
+
+def download_zoom_file(client: ZoomClient, url: str, download_directory: str) -> str:
+    # Note the token info in the client isn't really *public*, but it's
+    # not explicitly private, either. Use `config[]` syntax instead of
+    # `config.get()` so we get an exception if things have changed and
+    # this data is no longer available.
+    r = requests.get(url, stream=True, headers={
+        'Authorization': f'Bearer {client.config['token']}'
+    })
+    raise_for_status(r)
+    resolved_url = r.url
+    filename = os.path.basename(urlsplit(resolved_url).path)
+    filepath = os.path.join(download_directory, filename)
+    if os.path.exists(filepath):
+        r.close()
+        return filepath
+
+    with open(filepath, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk:  # filter out keep-alive new chunks
+                f.write(chunk)
+
+    return filepath

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -1,47 +1,52 @@
 #!/usr/bin/env python
-#
-# Description:
-#
-#      This script will download cloud recordings from Zoom Meetings, and
-#      upload them to YouTube.
-#
-# Usage:
-#
-#      python scripts/upload_zoom_recordings.py
-#
-# Environment Variables:
-#
-#     EDGI_ZOOM_CLIENT_ID - Client ID for the Zoom OAuth app for this script
-#     ZOOM_CLIENT_SECRET - Client Secret for the Zoom OAuth app for this script
-#     ZOOM_ACCOUNT_ID - Account ID for the Zoom OAuth app for this script
-#     EDGI_ZOOM_DELETE_AFTER_UPLOAD - If set to 'true', cloud recording will be
-#         deleted after upload to YouTube.
-#
-# Configuration:
-#
-#     This script expects one file to be available to enable YouTube upload:
-#
-#     * `.youtube-upload-credentials.json`
-#
-#     See README for how to generate this files.
+
+"""
+Description:
+
+    This script downloads cloud recordings from Zoom Meetings and uploads
+    them to YouTube or Google Drive.
+
+Usage:
+
+    python scripts/upload_zoom_recordings.py
+
+Environment Variables:
+
+    EDGI_ZOOM_CLIENT_ID - Client ID for the Zoom OAuth app for this script
+    ZOOM_CLIENT_SECRET - Client Secret for the Zoom OAuth app for this script
+    ZOOM_ACCOUNT_ID - Account ID for the Zoom OAuth app for this script
+    EDGI_ZOOM_DELETE_AFTER_UPLOAD - If set to 'true', cloud recording will be
+        deleted after upload to YouTube.
+
+Configuration:
+
+    This script expects one file to be available in your working directory to
+    enable YouTube upload:
+
+    * `.youtube-upload-credentials.json`
+
+    Or to enable Google Drive upload:
+
+    * `.gdrive-upload-credentials.json`
+
+    See README for how to generate these files.
+"""
 
 from argparse import ArgumentParser
-from datetime import datetime, date, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 import dateutil.parser
 import json
 import os
 import re
-import requests
 import subprocess
 import sys
 import tempfile
-from typing import Dict
-from urllib.parse import urlsplit
 from zoomus import ZoomClient
 from zoomus.util import encode_uuid
 from lib.constants import MEDIA_TYPE_FOR_EXTENSION, VIDEO_CATEGORY_IDS, ZOOM_ROLES
 from lib.youtube import get_youtube_client, upload_video, add_video_to_playlist, validate_youtube_credentials
 from lib.gdrive import get_gdrive_client, validate_gdrive_credentials, ensure_folder, is_trashed, upload_file
+from lib.zoom import RecordingStatus, ZoomError, download_zoom_file, parse_zoom
 
 ZOOM_CLIENT_ID = os.environ['EDGI_ZOOM_CLIENT_ID']
 ZOOM_CLIENT_SECRET = os.environ['EDGI_ZOOM_CLIENT_SECRET']
@@ -69,35 +74,6 @@ ZOOM_DELETE_AFTER_UPLOAD = is_truthy(os.environ.get('EDGI_ZOOM_DELETE_AFTER_UPLO
 DRY_RUN = is_truthy(os.environ.get('EDGI_DRY_RUN', ''))
 
 
-class ZoomError(Exception):
-    def __init__(self, response, message=None):
-        try:
-            data = response.json()
-        except Exception:
-            data = {}
-
-        if not message:
-            message = data.pop('message', 'Zoom API error!')
-
-        data['http_status'] = response.status_code
-        full_message = f'{message} ({data!r}) Check the docs for details: https://developers.zoom.us/docs/api/.'
-        super().__init__(full_message)
-
-    @classmethod
-    def is_error(cls, response):
-        return response.status_code >= 400
-
-    @classmethod
-    def raise_if_error(cls, response, message=None):
-        if cls.is_error(response):
-            raise cls(response, message)
-
-    @classmethod
-    def parse_or_raise(cls, response, message=None) -> Dict:
-        cls.raise_if_error(response, message)
-        return response.json()
-
-
 def fix_date(date_string: str) -> str:
     date = date_string
     index = date.find('Z')
@@ -110,46 +86,13 @@ def pretty_date(date_string: str) -> str:
     return datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ').strftime('%b %-d, %Y')
 
 
-def download_zoom_file(client: ZoomClient, url: str, download_directory: str) -> str:
-    # Note the token info in the client isn't really *public*, but it's
-    # not explicitly private, either. Use `config[]` syntax instead of
-    # `config.get()` so we get an exception if things have changed and
-    # this data is no longer available.
-    r = requests.get(url, stream=True, headers={
-        'Authorization': f'Bearer {client.config['token']}'
-    })
-    r.raise_for_status()
-    resolved_url = r.url
-    filename = os.path.basename(urlsplit(resolved_url).path)
-    filepath = os.path.join(download_directory, filename)
-    if os.path.exists(filepath):
-        r.close()
-        return
-    with open(filepath, 'wb') as f:
-        for chunk in r.iter_content(chunk_size=1024):
-            if chunk:  # filter out keep-alive new chunks
-                f.write(chunk)
-
-    return filepath
-
-
-def meeting_had_no_participants(client: ZoomClient, meeting: Dict) -> bool:
-    participants = ZoomError.parse_or_raise(client.past_meeting.get_participants(meeting_id=meeting['uuid']))['participants']
+def meeting_had_no_participants(client: ZoomClient, meeting: dict) -> bool:
+    participants = parse_zoom(client.past_meeting.get_participants(meeting_id=meeting['uuid']))['participants']
 
     return all(
         any(p.search(u['name']) for p in ZOOM_IGNORE_USER_NAMES)
         for u in participants
     )
-
-
-def recording_status(meeting: Dict) -> str:
-    for file in meeting['recording_files']:
-        if file['recording_end'] == '':
-            return 'ongoing'
-        elif file['status'] != 'completed':
-            return 'processing'
-
-    return 'ready'
 
 
 def video_has_audio(file_path: str) -> bool:
@@ -373,7 +316,7 @@ def main():
 
         print('Looking for videos to upload between '
               f'{args.from_time} and {args.to_time}...')
-        meetings = ZoomError.parse_or_raise(zoom.recording.list(
+        meetings = parse_zoom(zoom.recording.list(
             user_id=zoom_user_id,
             start=args.from_time,
             end=args.to_time
@@ -389,19 +332,22 @@ def main():
                 print('  Skipping: meeting not in topic list.')
                 continue
 
-            status = recording_status(meeting)
-            if status != 'ready':
-                print(f'  Skipping: recording is still {status}.')
+            status = RecordingStatus.from_meeting(meeting)
+            if status != RecordingStatus.READY:
+                print(f'  Skipping: recording is still {status.name}.')
                 continue
 
             if meeting_had_no_participants(zoom, meeting):
                 print('  Deleting recording: nobody attended this meeting.')
                 if not dry_run:
-                    response = zoom.recording.delete(meeting_id=encode_uuid(meeting['uuid']), action='trash')
-                    if response.status_code < 300:
+                    try:
+                        parse_zoom(zoom.recording.delete(
+                            meeting_id=encode_uuid(meeting['uuid']),
+                            action='trash'
+                        ))
                         print('  🗑️ Deleted recording.')
-                    else:
-                        print(f'  ❌ {ZoomError(response)}')
+                    except ZoomError as error:
+                        print(f'  ❌ {error}')
                 continue
 
             # FIXME: we now want to upload all files to gdrive
@@ -430,16 +376,16 @@ def main():
                     print('    Skipping upload: video was silent (no mics were on).')
 
                 if ZOOM_DELETE_AFTER_UPLOAD and not dry_run:
-                    # Just delete the video for now, since that takes the most storage space.
-                    response = zoom.recording.delete_single_recording(
-                        meeting_id=encode_uuid(file['meeting_id']),
-                        recording_id=file['id'],
-                        action='trash'
-                    )
-                    if response.status_code == 204:
+                    try:
+                        # Just delete the video for now, since that takes the most storage space.
+                        parse_zoom(zoom.recording.delete_single_recording(
+                            meeting_id=encode_uuid(file['meeting_id']),
+                            recording_id=file['id'],
+                            action='trash'
+                        ))
                         print(f'  🗑️ Deleted {file["file_type"]} file from Zoom for recording: {meeting["topic"]}')
-                    else:
-                        print(f'  ❌ {ZoomError(response)}')
+                    except ZoomError as error:
+                        print(f'  ❌ {error}')
 
 
 if __name__ == '__main__':

--- a/scripts/upload_zoom_recordings.py
+++ b/scripts/upload_zoom_recordings.py
@@ -43,10 +43,10 @@ import sys
 import tempfile
 from zoomus import ZoomClient
 from zoomus.util import encode_uuid
-from lib.constants import MEDIA_TYPE_FOR_EXTENSION, VIDEO_CATEGORY_IDS, ZOOM_ROLES
+from lib.constants import MEDIA_TYPE_FOR_EXTENSION, VIDEO_CATEGORY_IDS
 from lib.youtube import get_youtube_client, upload_video, add_video_to_playlist, validate_youtube_credentials
 from lib.gdrive import get_gdrive_client, validate_gdrive_credentials, ensure_folder, is_trashed, upload_file
-from lib.zoom import RecordingStatus, ZoomError, download_zoom_file, parse_zoom
+from lib.zoom import RecordingStatus, ZoomError, ZoomRole, download_zoom_file, parse_zoom
 
 ZOOM_CLIENT_ID = os.environ['EDGI_ZOOM_CLIENT_ID']
 ZOOM_CLIENT_SECRET = os.environ['EDGI_ZOOM_CLIENT_SECRET']
@@ -309,7 +309,7 @@ def main():
     zoom = ZoomClient(ZOOM_CLIENT_ID, ZOOM_CLIENT_SECRET, ZOOM_ACCOUNT_ID)
 
     # Official meeting recordings we will upload belong to the account owner.
-    zoom_user_id = zoom.user.list(role_id=ZOOM_ROLES['owner']).json()['users'][0]['id']
+    zoom_user_id = zoom.user.list(role_id=ZoomRole.OWNER).json()['users'][0]['id']
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         print(f'Creating tmp dir: {tmpdirname}\n')


### PR DESCRIPTION
This is a simplified and less ambitious version of #76, which has sat unmerged FOREVER because I am unhappy with it.

Back in #73, I added a bunch of error-handling code for Zoom, but it is both awkward and adds a lot of extra stuff to the recording upload script. This moves all the Zoom-specific utilities to their own module (`lib.zoom`) and attempts to smooth out the API a little bit. It's not ideal, but I think it makes the current code much more readable and manageable.

In a more perfect world, I’d upstream a lot of this stuff to zoomus, but it seems dead, and the maintainer isn’t really responding to issues and PRs. Or we’d switch to something like [basic-zoom](https://github.com/jsteinberg1/basic_zoom), but I am skeptical of using it because of the short release history, long time since updates, and lack of watchers/stars/past issues. Or we’d write our own thing similar to that, but I don’t know if we want that maintenance burden (and these things always turn out to be more complex than you expect…). The state of Zoom API wrappers for Python seems surprisingly poor!